### PR TITLE
feat: configurable max range

### DIFF
--- a/locale/en/linked-belts.cfg
+++ b/locale/en/linked-belts.cfg
@@ -1,2 +1,14 @@
 [entity-name]
 linked-belts=Linked __1__
+
+[mod-setting-name]
+linked-belts-range=__1__ Range
+linked-belts-same-surface=Same Surface
+
+[mod-setting-description]
+linked-belts-range=The maximum range allowed for the __1__. This is caculated using the maximum of the absolute difference between the x and y coordinates between the two belts. Default is 0 which means that the range is unlimited.
+linked-belts-same-surface=Require linked belts to be on the same surface to connect
+
+[linked-belts]
+lb-same-surface=Linked belts must be on the same surface
+lb-too-far=Too far away, max range is __1__

--- a/settings.lua
+++ b/settings.lua
@@ -1,0 +1,33 @@
+local belt_tiers = {
+    "underground-belt",
+    "fast-underground-belt",
+    "express-underground-belt",
+    "turbo-underground-belt",
+}
+
+data:extend({
+    {
+        type = "bool-setting",
+        name = "lb-linked-belts-same-surface",
+        localised_name = {"mod-setting-name.linked-belts-same-surface"},
+        localised_description = {"mod-setting-description.linked-belts-same-surface"},
+        setting_type = "runtime-global",
+        default_value = true,
+    }
+})
+
+for i, belt_tier in ipairs(belt_tiers) do
+    data:extend({
+        {
+            type = "int-setting",
+            name = "lb-linked-"..belt_tier.."-range",
+            localised_name = {"mod-setting-name.linked-belts-range", {"entity-name."..belt_tier}},
+            localised_description = {"mod-setting-description.linked-belts-range", {"entity-name."..belt_tier}},
+            setting_type = "runtime-global",
+            default_value = 0,
+            minimum_value = 0,
+            maximum_value = 86400,
+            order = "a"..i
+        },
+    })
+end


### PR DESCRIPTION
This might miss some edge cases, but in my limited testing, preventing the entity from being placed based on a rudimentary distance setting seems to work fine. I'd be better if we didn't have to let it be placed, I'm sure there's a way to do that but I couldn't find a way to cancel it during `pre_build`.

I've also added a setting to require belts to be on the safe surface to link.